### PR TITLE
Fix column name

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,5 +1,6 @@
 class PetsController < ApplicationController
   def index
+    @pets = Pet.all
   end
 
   def new

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,2 +1,14 @@
-<h1>Pets#index</h1>
-<p>Find me in app/views/pets/index.html.erb</p>
+<div class="container">
+  <h1>Pets</h1>
+  <% @pets.each do |pet| %>
+    <div class="card pet-card">
+      <p class="pet-name"><%= pet.name %></p>
+      <div class="d-flex justify-content-around">
+        <p class="pet-type"><%= pet.type %></p>
+        <p class="pet-danger">Danger Meter: <%= pet.danger_meter %>/5</p>
+        <p class="pet-price"><%= pet.price %></p>
+      </div>
+      <p class="pet-description"><%= pet.description %></p>
+    </div>
+  <% end %>
+</div>

--- a/db/migrate/20210607063314_change_column_name.rb
+++ b/db/migrate/20210607063314_change_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeColumnName < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :pets, :type, :species
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_052402) do
+ActiveRecord::Schema.define(version: 2021_06_07_052953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "pets", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.string "type"
+    t.integer "danger_meter"
+    t.float "price"
+    t.string "location"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_pets_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +40,5 @@ ActiveRecord::Schema.define(version: 2021_06_07_052402) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "pets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_052953) do
+ActiveRecord::Schema.define(version: 2021_06_07_063314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_052953) do
   create_table "pets", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.string "type"
+    t.string "species"
     t.integer "danger_meter"
     t.float "price"
     t.string "location"


### PR DESCRIPTION
Pets had a column called "type". This name is reserved for certain things causing an error so I ran a migration renaming it to "species".